### PR TITLE
use pin GitHub Actions digests in Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
 		":timezone(Asia/Tokyo)",
 		":prHourlyLimitNone",
 		":automergeRequireAllStatusChecks",
+    "helpers:pinGitHubActionsDigests",
 		"schedule:weekends"
 	],
 	"dependencyDashboard": true


### PR DESCRIPTION
use github actions digests

FYI: https://zenn.dev/tasshi/articles/renovate-pin-third-party-actions